### PR TITLE
feat: add zod default values to process.env

### DIFF
--- a/src/zod-config-static.ts
+++ b/src/zod-config-static.ts
@@ -27,6 +27,14 @@ export class ZodConfigStatic<Schema extends UnknownZodObjectSchema> {
     }
 
     this.config = schema.parse(configObject) as z.infer<Schema>;
+
+    // adds zod default values to the process.env object
+    for (const key in this.config) {
+      if (process.env[key] === undefined || process.env[key] === '') {
+        // notice that process.env only accepts string values
+        process.env[key] = String(this.config[key] ?? '');
+      }
+    }
   }
 
   get<K extends keyof z.infer<Schema>>(key: K): z.infer<Schema>[K] {

--- a/tests/zod-config-static.spec.ts
+++ b/tests/zod-config-static.spec.ts
@@ -1,0 +1,31 @@
+import { it, describe, expect } from 'vitest';
+import { z } from 'zod';
+
+import { ZodConfigStatic } from '../src/zod-config-static';
+
+describe('zod-config-static', () => {
+  it('should add the schema defaults to process.env', () => {
+    const ConfigSchema = z.object({
+      SOME_VAR_WITH_DEFAULT: z.string().default('a default value'),
+    })
+
+    expect(process.env.SOME_VAR_WITH_DEFAULT).toBeUndefined();
+
+    const config = new ZodConfigStatic(ConfigSchema);
+
+    expect(process.env.SOME_VAR_WITH_DEFAULT).toBe('a default value');
+  });
+
+  it('should add the schema defaults to process.env, coercing to string if needed', () => {
+    const ConfigSchema = z.object({
+      OTHER_VAR_WITH_DEFAULT: z.coerce.number().default(42),
+    })
+
+    expect(process.env.OTHER_VAR_WITH_DEFAULT).toBeUndefined();
+
+    const config = new ZodConfigStatic(ConfigSchema);
+
+    expect(config.get('OTHER_VAR_WITH_DEFAULT')).toBe(42);
+    expect(process.env.OTHER_VAR_WITH_DEFAULT).toBe('42');
+  });
+});


### PR DESCRIPTION
When the zod schema has default values, it's probably good to add them to the `process.env`

use case: libraries that interacts directly with the `process.env` instead of the Config module.

ex:
`NO_COLOR=1` is an env var used internally by NestJS Logger. So, adding it to the zod schema with a default value doesn't make any change to the behaviour. 